### PR TITLE
Fix matching for signature methods

### DIFF
--- a/sdk/adaptive-proxy/lib/adaptive.js
+++ b/sdk/adaptive-proxy/lib/adaptive.js
@@ -604,8 +604,9 @@ class Adaptive {
       if (assessment.allowedFactors) {
         enrolledFactors = enrolledFactors.filter((enrollment) =>
           assessment.allowedFactors.includes(enrollment.type) ||
-          (assessment.allowedFactors.includes('signatures') &&
-          enrollment.type === 'signature'));
+          (enrollment.type === 'signature' &&
+           assessment.allowedFactors.includes("signatures_"
+             + enrollment.subType)));
       }
 
       console.log(`[${Adaptive.name}:_validateAssertion(transactionId, ` +

--- a/sdk/adaptive-proxy/lib/adaptive.js
+++ b/sdk/adaptive-proxy/lib/adaptive.js
@@ -605,7 +605,7 @@ class Adaptive {
         enrolledFactors = enrolledFactors.filter((enrollment) =>
           assessment.allowedFactors.includes(enrollment.type) ||
           (enrollment.type === 'signature' &&
-           assessment.allowedFactors.includes("signatures_"
+           assessment.allowedFactors.includes('signatures_'
              + enrollment.subType)));
       }
 


### PR DESCRIPTION
Modified code that matches allowed methods against enrolled methods so that "signature" type in enrolled method matches signatures_<subtype> in allowed methods.